### PR TITLE
remove CAMLparam2 from caml_crypto_gen_key to avoid segfault (not a O…

### DIFF
--- a/crypto/nacl_stubs.c
+++ b/crypto/nacl_stubs.c
@@ -25,7 +25,6 @@ CAMLprim value caml_sodium_init(value __unused v_unit) {
 }
 
 void caml_crypto_gen_key(value key_buf, value key_len) {
-  CAMLparam2 (key_buf, key_len);
   randombytes_buf(Bytes_val(key_buf), Int_val(key_len));
 }
 


### PR DESCRIPTION
…Caml-FFI function, no need to register the parameters)

Signed-off-by: Hannes Mehnert <hannes@mehnert.org>